### PR TITLE
Improve performance of chunk_iter

### DIFF
--- a/git_code_debt/util/iter.py
+++ b/git_code_debt/util/iter.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import itertools
+
 
 def chunk_iter(iterable, n):
     """Yields an iterator in chunks
@@ -8,7 +10,7 @@ def chunk_iter(iterable, n):
     For example you can do
 
     for a, b in chunk_iter([1, 2, 3, 4, 5, 6], 2):
-        print '{0} {1}'.format(a, b)
+        print('{0} {1}'.format(a, b))
 
     # Prints
     # 1 2
@@ -20,11 +22,9 @@ def chunk_iter(iterable, n):
         n - Chunk size (must be greater than 0)
     """
     assert n > 0
-    iterable = tuple(iterable)
+    iterable = iter(iterable)
 
-    chunk = iterable[:n]
-    iterable = iterable[n:]
+    chunk = tuple(itertools.islice(iterable, n))
     while chunk:
         yield chunk
-        chunk = iterable[:n]
-        iterable = iterable[n:]
+        chunk = tuple(itertools.islice(iterable, n))


### PR DESCRIPTION
Profiled this and found it was a hotspot for generating against large repositories (as much as 7-10% of time was spent in this function).  After the modifications it doesn't even show up on a profile.