### PR TITLE
Clone with --shared to speed up local clones

### DIFF
--- a/git_code_debt/repo_parser.py
+++ b/git_code_debt/repo_parser.py
@@ -29,7 +29,11 @@ class RepoParser(object):
         self.tempdir = tempfile.mkdtemp(suffix='temp-repo')
         try:
             subprocess.check_call(
-                ('git', 'clone', '--no-checkout', self.git_repo, self.tempdir),
+                (
+                    'git', 'clone',
+                    '--no-checkout', '--shared',
+                    self.git_repo, self.tempdir,
+                ),
                 stdout=None,
             )
             yield


### PR DESCRIPTION
Compare
```
$ rm -rf yelp-main && time git clone --shared --no-checkout /nail/git/yelp-main.git
Cloning into 'yelp-main'...
done.

real	0m0.262s
user	0m0.149s
sys	0m0.114s
$ rm -rf yelp-main && time git clone --no-checkout /nail/git/yelp-main.git
Cloning into 'yelp-main'...
done.

real	0m36.027s
user	0m0.204s
sys	0m3.277s

```