### PR TITLE
Pass the commit object along to metric parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,12 @@ class DiffParserBase(object):
     # Specify __metric__ = False to not be included (useful for base classes)
     __metric__ = False
 
-    def get_metrics_from_stat(self, file_diff_stats):
+    def get_metrics_from_stat(self, commit, file_diff_stats):
         """Implement me to yield Metric objects from the input list of
         FileStat objects.
 
         Args:
+            commit - Commit object
             file_diff_stats - list of FileDiffStat objects
 
         Returns:

--- a/git_code_debt/generate.py
+++ b/git_code_debt/generate.py
@@ -27,11 +27,13 @@ from git_code_debt.write_logic import insert_metric_changes
 from git_code_debt.write_logic import insert_metric_values
 
 
-def get_metrics(diff, metric_parsers):
+def get_metrics(commit, diff, metric_parsers):
     def get_all_metrics(file_diff_stats):
         for metric_parser_cls in metric_parsers:
             metric_parser = metric_parser_cls()
-            for metric in metric_parser.get_metrics_from_stat(file_diff_stats):
+            for metric in metric_parser.get_metrics_from_stat(
+                commit, file_diff_stats,
+            ):
                 yield metric
 
     file_diff_stats = get_file_diff_stats_from_output(diff)
@@ -49,7 +51,7 @@ def _get_metrics_inner(m_args):
         diff = repo_parser.get_original_commit(commit.sha)
     else:
         diff = repo_parser.get_commit_diff(compare_commit.sha, commit.sha)
-    return get_metrics(diff, metric_parsers)
+    return get_metrics(commit, diff, metric_parsers)
 
 
 def load_data(

--- a/git_code_debt/metrics/base.py
+++ b/git_code_debt/metrics/base.py
@@ -9,11 +9,12 @@ class DiffParserBase(object):
     # Specify __metric__ = False to not be included (useful for base classes)
     __metric__ = False
 
-    def get_metrics_from_stat(self, file_diff_stats):
+    def get_metrics_from_stat(self, commit, file_diff_stats):
         """Implement me to yield Metric objects from the input list of
         FileStat objects.
 
         Args:
+            commit - Commit object
             file_diff_stats - list of FileDiffStat objects
 
         Returns:
@@ -29,7 +30,7 @@ class SimpleLineCounterBase(DiffParserBase):
     """Simple counter for various file types and line types."""
     __metric__ = False
 
-    def get_metrics_from_stat(self, file_diff_stats):
+    def get_metrics_from_stat(self, _, file_diff_stats):
         metric_value = 0
 
         for file_diff_stat in file_diff_stats:

--- a/git_code_debt/metrics/binary_file_count.py
+++ b/git_code_debt/metrics/binary_file_count.py
@@ -8,7 +8,7 @@ from git_code_debt.metrics.base import DiffParserBase
 
 
 class BinaryFileCount(DiffParserBase):
-    def get_metrics_from_stat(self, file_diff_stats):
+    def get_metrics_from_stat(self, _, file_diff_stats):
         binary_delta = 0
 
         for file_diff_stat in file_diff_stats:

--- a/git_code_debt/metrics/curse.py
+++ b/git_code_debt/metrics/curse.py
@@ -21,7 +21,7 @@ def count_curse_words(lines):
 class CurseWordsParser(DiffParserBase):
     """Counts curse words in a repository, overall and by file type"""
 
-    def get_metrics_from_stat(self, file_diff_stats):
+    def get_metrics_from_stat(self, _, file_diff_stats):
         total_curses = 0
         curses_by_file_type = collections.defaultdict(int)
 

--- a/git_code_debt/metrics/lines.py
+++ b/git_code_debt/metrics/lines.py
@@ -11,7 +11,7 @@ from git_code_debt.metrics.common import FILE_TYPE_MAP
 class LinesOfCodeParser(DiffParserBase):
     """Counts lines of code in a repository, overall and by file types."""
 
-    def get_metrics_from_stat(self, file_diff_stats):
+    def get_metrics_from_stat(self, _, file_diff_stats):
         total_lines = 0
         lines_by_file_type = collections.defaultdict(int)
 

--- a/git_code_debt/metrics/submodule_count.py
+++ b/git_code_debt/metrics/submodule_count.py
@@ -8,7 +8,7 @@ from git_code_debt.metrics.base import DiffParserBase
 
 
 class SubmoduleCount(DiffParserBase):
-    def get_metrics_from_stat(self, file_diff_stats):
+    def get_metrics_from_stat(self, _, file_diff_stats):
         submodule_delta = 0
 
         for file_diff_stat in file_diff_stats:

--- a/git_code_debt/metrics/symlink_count.py
+++ b/git_code_debt/metrics/symlink_count.py
@@ -8,7 +8,7 @@ from git_code_debt.metrics.base import DiffParserBase
 
 
 class SymlinkCount(DiffParserBase):
-    def get_metrics_from_stat(self, file_diff_stats):
+    def get_metrics_from_stat(self, _, file_diff_stats):
         symlink_delta = 0
 
         for file_diff_stat in file_diff_stats:

--- a/git_code_debt/repo_parser.py
+++ b/git_code_debt/repo_parser.py
@@ -11,7 +11,8 @@ from git_code_debt.util.iter import chunk_iter
 from git_code_debt.util.subprocess import cmd_output
 
 
-Commit = collections.namedtuple('Commit', ['sha', 'date'])
+Commit = collections.namedtuple('Commit', ('sha', 'date'))
+Commit.blank = Commit('0' * 40, 0)
 
 COMMIT_FORMAT = '--format=%H%n%ct'
 

--- a/git_code_debt/server/servlets/widget.py
+++ b/git_code_debt/server/servlets/widget.py
@@ -10,6 +10,7 @@ import yaml
 from git_code_debt.discovery import get_metric_parsers_from_args
 from git_code_debt.generate import get_metrics
 from git_code_debt.generate_config import GenerateOptions
+from git_code_debt.repo_parser import Commit
 from git_code_debt.server.metric_config import widget_metrics
 from git_code_debt.server.presentation.commit_delta import CommitDeltaPresenter
 from git_code_debt.server.presentation.delta import DeltaPresenter
@@ -35,7 +36,7 @@ def data():
     parsers = get_metric_parsers_from_args(
         metric_config.metric_package_names, skip_defaults=False,
     )
-    metrics = get_metrics(diff, parsers)
+    metrics = get_metrics(Commit.blank, diff, parsers)
     metrics = [
         metric for metric in metrics
         if metric.value and metric.name in metric_names

--- a/tests/metrics/base_test.py
+++ b/tests/metrics/base_test.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from git_code_debt.file_diff_stat import FileDiffStat
 from git_code_debt.metric import Metric
 from git_code_debt.metrics.base import SimpleLineCounterBase
+from git_code_debt.repo_parser import Commit
 
 
 def test_simple_base_counter():
@@ -27,7 +28,7 @@ def test_simple_base_counter():
         ),
     ]
 
-    metrics = list(parser.get_metrics_from_stat(input_stats))
+    metrics = list(parser.get_metrics_from_stat(Commit.blank, input_stats))
     assert metrics == [Metric('TestCounter', 2)]
 
 

--- a/tests/metrics/binary_file_count_test.py
+++ b/tests/metrics/binary_file_count_test.py
@@ -7,6 +7,7 @@ from git_code_debt.file_diff_stat import SpecialFileType
 from git_code_debt.file_diff_stat import Status
 from git_code_debt.metric import Metric
 from git_code_debt.metrics.binary_file_count import BinaryFileCount
+from git_code_debt.repo_parser import Commit
 
 
 def test_binary_file_count_detects_added():
@@ -18,7 +19,7 @@ def test_binary_file_count_detects_added():
         ),
     ]
 
-    metrics = list(parser.get_metrics_from_stat(input_stats))
+    metrics = list(parser.get_metrics_from_stat(Commit.blank, input_stats))
     assert metrics == [Metric('BinaryFileCount', 1)]
 
 
@@ -31,7 +32,7 @@ def test_binary_file_count_detects_deleted():
         ),
     ]
 
-    metrics = list(parser.get_metrics_from_stat(input_stats))
+    metrics = list(parser.get_metrics_from_stat(Commit.blank, input_stats))
     assert metrics == [Metric('BinaryFileCount', -1)]
 
 
@@ -44,5 +45,5 @@ def test_binary_file_count_detects_ignores_moved():
         ),
     ]
 
-    metrics = list(parser.get_metrics_from_stat(input_stats))
+    metrics = list(parser.get_metrics_from_stat(Commit.blank, input_stats))
     assert metrics == [Metric('BinaryFileCount', 0)]

--- a/tests/metrics/curse_test.py
+++ b/tests/metrics/curse_test.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from git_code_debt.file_diff_stat import FileDiffStat
 from git_code_debt.metric import Metric
 from git_code_debt.metrics.curse import CurseWordsParser
+from git_code_debt.repo_parser import Commit
 
 
 def test_curse_words_parser():
@@ -22,6 +23,6 @@ def test_curse_words_parser():
             None,
         ),
     ]
-    metrics = list(parser.get_metrics_from_stat(input_stats))
+    metrics = list(parser.get_metrics_from_stat(Commit.blank, input_stats))
     assert Metric('TotalCurseWords_Template', 1) in metrics
     assert Metric('TotalCurseWords_Python', 0) in metrics

--- a/tests/metrics/imports_test.py
+++ b/tests/metrics/imports_test.py
@@ -9,6 +9,7 @@ from git_code_debt.metrics.imports import CheetahTemplateImportCount
 from git_code_debt.metrics.imports import is_python_import
 from git_code_debt.metrics.imports import is_template_import
 from git_code_debt.metrics.imports import PythonImportCount
+from git_code_debt.repo_parser import Commit
 
 
 @pytest.mark.parametrize(('line', 'expected'), (
@@ -49,7 +50,7 @@ def test_python_import_parser():
         ),
     ]
 
-    metrics = list(parser.get_metrics_from_stat(input_stats))
+    metrics = list(parser.get_metrics_from_stat(Commit.blank, input_stats))
     assert metrics == [Metric('PythonImportCount', 1)]
 
 
@@ -64,5 +65,5 @@ def test_template_import_parser():
         ),
     ]
 
-    metrics = list(parser.get_metrics_from_stat(input_stats))
+    metrics = list(parser.get_metrics_from_stat(Commit.blank, input_stats))
     assert metrics == [Metric('CheetahTemplateImportCount', 1)]

--- a/tests/metrics/lines_in_init_test.py
+++ b/tests/metrics/lines_in_init_test.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from git_code_debt.file_diff_stat import FileDiffStat
 from git_code_debt.metric import Metric
 from git_code_debt.metrics.lines_in_init import Python__init__LineCount
+from git_code_debt.repo_parser import Commit
 
 
 def test_lines_in_init():
@@ -16,5 +17,5 @@ def test_lines_in_init():
             None,
         ),
     ]
-    metrics = list(parser.get_metrics_from_stat(input_stats))
+    metrics = list(parser.get_metrics_from_stat(Commit.blank, input_stats))
     assert metrics == [Metric('Python__init__LineCount', 1)]

--- a/tests/metrics/lines_test.py
+++ b/tests/metrics/lines_test.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 from git_code_debt.file_diff_stat import FileDiffStat
 from git_code_debt.metrics.lines import LinesOfCodeParser
+from git_code_debt.repo_parser import Commit
 
 
 def test_lines_of_code_parser():
@@ -12,7 +13,7 @@ def test_lines_of_code_parser():
         FileDiffStat(b'womp.yaml', [b'a', b'b', b'c'], [b'hi'], None),
     ]
 
-    metrics = list(parser.get_metrics_from_stat(input_stats))
+    metrics = list(parser.get_metrics_from_stat(Commit.blank, input_stats))
 
     expected_value = {
         'TotalLinesOfCode': 3,

--- a/tests/metrics/submodule_count_test.py
+++ b/tests/metrics/submodule_count_test.py
@@ -7,6 +7,7 @@ from git_code_debt.file_diff_stat import SpecialFileType
 from git_code_debt.file_diff_stat import Status
 from git_code_debt.metric import Metric
 from git_code_debt.metrics.submodule_count import SubmoduleCount
+from git_code_debt.repo_parser import Commit
 
 
 def test_submodule_count_detects_added():
@@ -18,7 +19,7 @@ def test_submodule_count_detects_added():
         ),
     ]
 
-    metrics = list(parser.get_metrics_from_stat(input_stats))
+    metrics = list(parser.get_metrics_from_stat(Commit.blank, input_stats))
     assert metrics == [Metric('SubmoduleCount', 1)]
 
 
@@ -31,7 +32,7 @@ def test_submodule_count_detects_deleted():
         ),
     ]
 
-    metrics = list(parser.get_metrics_from_stat(input_stats))
+    metrics = list(parser.get_metrics_from_stat(Commit.blank, input_stats))
     assert metrics == [Metric('SubmoduleCount', -1)]
 
 
@@ -44,5 +45,5 @@ def test_submodule_count_detects_ignores_moved():
         ),
     ]
 
-    metrics = list(parser.get_metrics_from_stat(input_stats))
+    metrics = list(parser.get_metrics_from_stat(Commit.blank, input_stats))
     assert metrics == [Metric('SubmoduleCount', 0)]

--- a/tests/metrics/symlink_count_test.py
+++ b/tests/metrics/symlink_count_test.py
@@ -7,6 +7,7 @@ from git_code_debt.file_diff_stat import SpecialFileType
 from git_code_debt.file_diff_stat import Status
 from git_code_debt.metric import Metric
 from git_code_debt.metrics.symlink_count import SymlinkCount
+from git_code_debt.repo_parser import Commit
 
 
 def test_symlink_count_detects_added():
@@ -18,7 +19,7 @@ def test_symlink_count_detects_added():
         ),
     ]
 
-    metrics = list(parser.get_metrics_from_stat(input_stats))
+    metrics = list(parser.get_metrics_from_stat(Commit.blank, input_stats))
     assert metrics == [Metric('SymlinkCount', 1)]
 
 
@@ -31,7 +32,7 @@ def test_symlink_count_detects_deleted():
         ),
     ]
 
-    metrics = list(parser.get_metrics_from_stat(input_stats))
+    metrics = list(parser.get_metrics_from_stat(Commit.blank, input_stats))
     assert metrics == [Metric('SymlinkCount', -1)]
 
 
@@ -44,5 +45,5 @@ def test_symlink_count_detects_ignores_moved():
         ),
     ]
 
-    metrics = list(parser.get_metrics_from_stat(input_stats))
+    metrics = list(parser.get_metrics_from_stat(Commit.blank, input_stats))
     assert metrics == [Metric('SymlinkCount', 0)]

--- a/tests/metrics/todo_test.py
+++ b/tests/metrics/todo_test.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from git_code_debt.file_diff_stat import FileDiffStat
 from git_code_debt.metric import Metric
 from git_code_debt.metrics.todo import TODOCount
+from git_code_debt.repo_parser import Commit
 
 
 def test_parser():
@@ -16,5 +17,5 @@ def test_parser():
             None,
         ),
     ]
-    metrics = list(parser.get_metrics_from_stat(input_stats))
+    metrics = list(parser.get_metrics_from_stat(Commit.blank, input_stats))
     assert metrics == [Metric('TODOCount', 1)]


### PR DESCRIPTION
This would allow one to write metrics based on date (part of the Commit object)